### PR TITLE
Add JAXB dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ repositories {
 }
 
 dependencies {
+    compile("javax.xml.bind:jaxb-api:2.3.0")
+    compile("org.glassfish.jaxb:jaxb-runtime:2.3.1")
 
     compile("org.springframework.boot:spring-boot-starter-web")
     compile("org.springframework.boot:spring-boot-starter-actuator")


### PR DESCRIPTION
Running the app with Java 11 throws exceptions due to missing JAXB dependencies.